### PR TITLE
Hot Fix: installing canela package will now include bin/*.yml files

### DIFF
--- a/canela/_version.py
+++ b/canela/_version.py
@@ -1,2 +1,2 @@
 """Single place to track version of canela package"""
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setuptools.setup(
                       'click~=7.1',
                       'pyyaml~=5.4'],
                       #'dscribe~= 0.4'],
+    package_data={'canela': ['bin/*.yml']},
     tests_require=['pytest~=6.0'])
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import setuptools
 
 # read in version of canela package
+v = {}
 with open('canela/_version.py', 'r') as fid:
     # this will create the __version__ variable to be used below
-    exec(fid.read())
+    exec(fid.read(), v)
 
 # use README file to create long description of package
 # ignore images (lines that start with '![')
@@ -13,7 +14,7 @@ with open('README.md', 'r') as readme:
 
 setuptools.setup(
     name='canela',
-    version=__version__,
+    version=v['__version__'],
     author='CANELa (Mpourmpakis Lab)',
     url='https://www.github.com/mpourmpakis/canela',
     description="CANELa tools to setup, track, and analyze comp chem calcs",


### PR DESCRIPTION
Tracking canela CLI tools occurs in `bin/script_info.yml`. Prior to this fix, installing the canela package with pip, like:
```bash
pip install git+https://github.com/mpourmpakis/canela
```
would not include `script_info.yml`, breaking the `canela` command. Now the file is included during installs and we can make appropriate updates to `setup.py` in the future if we need to include other data files.